### PR TITLE
Implement basic algorithm skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # basketball-highlight-reel
 AI-powered basketball highlight reel generator.
+
+## Development
+
+Run the server with:
+
+```bash
+npm run dev
+```
+
+### API Endpoints
+
+- `POST /api/renderPlan` – generate a simple render plan.
+- `POST /api/reel` – run the placeholder highlight-reel algorithm. Send `user`, `video` and `options` objects in the request body.
+
+### Algorithm
+
+See `highlightAlgorithm.js` for a high-level skeleton of the steps used to build a highlight reel. These functions are stubs that mirror the workflow described in the project documentation.

--- a/highlightAlgorithm.js
+++ b/highlightAlgorithm.js
@@ -1,0 +1,92 @@
+// High-level placeholder implementation of the basketball highlight reel algorithm.
+// Each function represents one of the steps described in the project documentation.
+
+function handleVideoUpload(video) {
+  // Validate input and extract metadata.
+  // In a real implementation this would check format, duration and fetch remote videos.
+  return {
+    ...video,
+    metadata: { duration: video.duration || 0, format: video.format || 'mp4' }
+  };
+}
+
+function processVideoSegments(video, focusMode, featuredPlayers, teamColors) {
+  // Segment the video based on focus mode and user preferences.
+  // This is a stub that returns a placeholder segment list.
+  return [
+    { start: 0, end: 10, label: 'intro' },
+    { start: 12, end: 20, label: 'dunk' }
+  ];
+}
+
+function detectHighlights(segments, focusMode, userSettings) {
+  // Run AI models on each segment to detect highlights.
+  // The real implementation would analyze the clip content.
+  return segments.map((seg) => ({ ...seg, confidence: 0.9 }));
+}
+
+function syncAudioWithVideo(clips, musicTrack, commentaryStyle) {
+  // Synchronize music and commentary with the supplied clips.
+  return clips.map((clip) => ({ ...clip, audio: { track: musicTrack, style: commentaryStyle } }));
+}
+
+function applyVideoTransitions(clips, transitionType, stylePreset) {
+  // Apply visual transitions between clips.
+  return clips.map((clip) => ({ ...clip, transition: { type: transitionType, style: stylePreset } }));
+}
+
+function renderHighlightReel(clips, resolution, format) {
+  // Combine clips and produce the final video.
+  return {
+    clips,
+    resolution,
+    format,
+    file: 'highlight-reel.' + (format || 'mp4')
+  };
+}
+
+function handleUserFeedback(feedback, video) {
+  // Adjust the video based on user feedback.
+  return { video, feedbackApplied: feedback };
+}
+
+function handleMonetization(userType, video) {
+  // Decide whether to show ads or enable premium rendering.
+  return { video, plan: userType };
+}
+
+function manageSubscription(user, paymentDetails) {
+  // Update subscription status and record payment history.
+  return { user, payment: paymentDetails };
+}
+
+function manageVideoStorage(user, video) {
+  // Store the rendered video and provide access links.
+  return { user, videoUrl: '/videos/' + video.file };
+}
+
+function createHighlightReel(user, video, options = {}) {
+  const uploadedVideo = handleVideoUpload(video);
+  const segments = processVideoSegments(uploadedVideo, options.focusMode, options.featuredPlayers, options.teamColors);
+  const highlights = detectHighlights(segments, options.focusMode, options.userSettings);
+  const withAudio = syncAudioWithVideo(highlights, options.musicTrack, options.commentaryStyle);
+  const withTransitions = applyVideoTransitions(withAudio, options.transitionType, options.stylePreset);
+  const finalVideo = renderHighlightReel(withTransitions, options.resolution, options.format);
+  manageVideoStorage(user, finalVideo);
+  return finalVideo;
+}
+
+module.exports = {
+  handleVideoUpload,
+  processVideoSegments,
+  detectHighlights,
+  syncAudioWithVideo,
+  applyVideoTransitions,
+  renderHighlightReel,
+  handleUserFeedback,
+  handleMonetization,
+  manageSubscription,
+  manageVideoStorage,
+  createHighlightReel
+};
+

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const generateRenderPlan = require('./renderPlan');
+const algorithm = require('./highlightAlgorithm');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -15,6 +16,12 @@ app.get('/api/health', (_req, res) => {
 app.post('/api/renderPlan', (req, res) => {
   const plan = generateRenderPlan(req.body || {});
   res.json({ plan });
+});
+
+app.post('/api/reel', (req, res) => {
+  const { user, video, options } = req.body || {};
+  const reel = algorithm.createHighlightReel(user || {}, video || {}, options || {});
+  res.json({ reel });
 });
 
 app.listen(PORT, () =>


### PR DESCRIPTION
## Summary
- add a placeholder `highlightAlgorithm` module implementing the project algorithm
- expose `/api/reel` endpoint that uses the algorithm skeleton
- document usage and endpoints in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842207c16e88323960db9b7a55aa97f