### PR TITLE
Add highlight algorithm skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # basketball-highlight-reel
 AI-powered basketball highlight reel generator.
+
+## API Endpoints
+
+### `POST /api/renderPlan`
+
+Generate a simple render plan for testing purposes.
+
+### `POST /api/generate`
+
+Runs the high-level highlight reel algorithm and returns a skeleton response
+containing selected clips and metadata. Supply a JSON body with `user`,
+`video`, and optional settings like `focusMode` or `musicTrack`.

--- a/highlightAlgorithm.js
+++ b/highlightAlgorithm.js
@@ -1,0 +1,89 @@
+// High-level algorithm for basketball highlight reel generation.
+
+function handleVideoUpload(video) {
+  // TODO: implement real video handling
+  return {
+    valid: true,
+    metadata: {
+      duration: video.duration || 0,
+      resolution: video.resolution || 'unknown'
+    },
+    source: video.source || 'upload'
+  };
+}
+
+function processVideoSegments(video, focusMode, featuredPlayers, teamColors) {
+  // Placeholder segmentation logic
+  return [
+    { start: 0, end: 10, label: 'intro' }
+  ];
+}
+
+function detectHighlights(segments, focusMode, userSettings) {
+  // Placeholder AI highlight detection
+  return segments.map(seg => ({ ...seg, score: 1 }));
+}
+
+function syncAudioWithVideo(clips, musicTrack, commentaryStyle) {
+  // Placeholder audio sync
+  return { clips, musicTrack, commentaryStyle };
+}
+
+function applyVideoTransitions(clips, transitionType, stylePreset) {
+  // Placeholder transitions
+  return clips;
+}
+
+function renderHighlightReel(clips, resolution, format) {
+  // Placeholder rendering
+  return {
+    resolution,
+    format,
+    clips
+  };
+}
+
+function handleUserFeedback(feedback, video) {
+  // Placeholder feedback handling
+  return { feedbackHandled: true };
+}
+
+function handleMonetization(userType, video) {
+  // Placeholder monetization logic
+  return { userType };
+}
+
+function manageSubscription(user, paymentDetails) {
+  // Placeholder subscription management
+  return { status: 'active' };
+}
+
+function manageVideoStorage(user, video) {
+  // Placeholder storage management
+  return { location: 'cloud' };
+}
+
+function createHighlightReel(user, video, options = {}) {
+  const uploadInfo = handleVideoUpload(video);
+  const segments = processVideoSegments(video, options.focusMode, options.featuredPlayers, options.teamColors);
+  const highlights = detectHighlights(segments, options.focusMode, options.userSettings);
+  const audio = syncAudioWithVideo(highlights, options.musicTrack, options.commentaryStyle);
+  const transitioned = applyVideoTransitions(audio.clips, options.transitionType, options.stylePreset);
+  const finalVideo = renderHighlightReel(transitioned, options.resolution || '1080p', options.format || 'mp4');
+  manageVideoStorage(user, finalVideo);
+  return finalVideo;
+}
+
+module.exports = {
+  handleVideoUpload,
+  processVideoSegments,
+  detectHighlights,
+  syncAudioWithVideo,
+  applyVideoTransitions,
+  renderHighlightReel,
+  handleUserFeedback,
+  handleMonetization,
+  manageSubscription,
+  manageVideoStorage,
+  createHighlightReel
+};

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const generateRenderPlan = require('./renderPlan');
+const highlightAlgo = require('./highlightAlgorithm');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -15,6 +16,14 @@ app.get('/api/health', (_req, res) => {
 app.post('/api/renderPlan', (req, res) => {
   const plan = generateRenderPlan(req.body || {});
   res.json({ plan });
+});
+
+app.post('/api/generate', (req, res) => {
+  const options = req.body || {};
+  const user = options.user || {};
+  const video = options.video || {};
+  const result = highlightAlgo.createHighlightReel(user, video, options);
+  res.json({ result });
 });
 
 app.listen(PORT, () =>


### PR DESCRIPTION
## Summary
- implement high-level highlight reel algorithm in `highlightAlgorithm.js`
- expose `/api/generate` route that uses the algorithm
- document new endpoint in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842208596a0832390e6d577a9347d70