### PR TITLE
Implement placeholder highlight algorithm and endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # basketball-highlight-reel
 AI-powered basketball highlight reel generator.
+
+## API
+
+- `GET /api/health` – basic health check.
+- `POST /api/renderPlan` – returns a demo render plan.
+- `POST /api/createHighlight` – runs the placeholder highlight algorithm and returns a mock highlight reel. Provide a JSON body with optional `user`, `video`, and `options` fields.

--- a/highlightAlgorithm.js
+++ b/highlightAlgorithm.js
@@ -1,0 +1,81 @@
+// Placeholder algorithm implementation for highlight reel generation
+
+function handleVideoUpload(video) {
+  // Validate format and extract basic metadata
+  return {
+    metadata: {
+      duration: video.duration || 0,
+      resolution: video.resolution || '720p'
+    },
+    video
+  };
+}
+
+function processVideoSegments(uploadResult, options = {}) {
+  // Segment video based on focus mode or featured players
+  return [
+    { start: 0, end: 10, label: 'intro' }
+  ];
+}
+
+function detectHighlights(segments, options = {}) {
+  // Assign a random score to each segment as a placeholder
+  return segments.map(seg => ({ ...seg, score: Math.random() }));
+}
+
+function syncAudioWithVideo(clips, musicTrack = '', commentaryStyle = 'default') {
+  return clips.map(clip => ({ ...clip, musicTrack, commentaryStyle }));
+}
+
+function applyVideoTransitions(clips, transitionType = 'fade', stylePreset = 'default') {
+  return clips.map(clip => ({ ...clip, transitionType, stylePreset }));
+}
+
+function renderHighlightReel(clips, resolution = '720p', format = 'mp4') {
+  return {
+    resolution,
+    format,
+    clips
+  };
+}
+
+function handleUserFeedback(feedback, reel) {
+  // Placeholder for a feedback loop
+  return reel;
+}
+
+function handleMonetization(userType, reel) {
+  return { userType, reel };
+}
+
+function manageSubscription(user, paymentDetails) {
+  return { user, paymentDetails };
+}
+
+function manageVideoStorage(user, video) {
+  return { user, video };
+}
+
+function createHighlightReel(user, video, options = {}) {
+  const uploaded = handleVideoUpload(video);
+  const segments = processVideoSegments(uploaded, options);
+  const highlights = detectHighlights(segments, options);
+  const withAudio = syncAudioWithVideo(highlights, options.musicTrack, options.commentaryStyle);
+  const withTransitions = applyVideoTransitions(withAudio, options.transitionType, options.stylePreset);
+  const reel = renderHighlightReel(withTransitions, options.resolution, options.format);
+  return reel;
+}
+
+module.exports = {
+  handleVideoUpload,
+  processVideoSegments,
+  detectHighlights,
+  syncAudioWithVideo,
+  applyVideoTransitions,
+  renderHighlightReel,
+  handleUserFeedback,
+  handleMonetization,
+  manageSubscription,
+  manageVideoStorage,
+  createHighlightReel
+};

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const generateRenderPlan = require('./renderPlan');
+const highlightAlgorithm = require('./highlightAlgorithm');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -15,6 +16,12 @@ app.get('/api/health', (_req, res) => {
 app.post('/api/renderPlan', (req, res) => {
   const plan = generateRenderPlan(req.body || {});
   res.json({ plan });
+});
+
+app.post('/api/createHighlight', (req, res) => {
+  const { user, video, options } = req.body || {};
+  const highlight = highlightAlgorithm.createHighlightReel(user || {}, video || {}, options || {});
+  res.json({ highlight });
 });
 
 app.listen(PORT, () =>


### PR DESCRIPTION
## Summary
- add `highlightAlgorithm.js` with skeleton algorithm functions
- expose `/api/createHighlight` endpoint using the new algorithm
- document API routes in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68422075b2d08323979ae15cfbc52003