### PR TITLE
Add highlight algorithm skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # basketball-highlight-reel
 AI-powered basketball highlight reel generator.
+
+## Development
+
+Run the API in development mode:
+
+```bash
+npm run dev
+```
+
+### Highlight Algorithm
+
+The `highlightAlgorithm.js` module contains a skeleton implementation of the
+workflow described in the project docs. It exposes helper functions for video
+upload, segmentation, highlight detection, transitions and rendering. The
+`/api/highlightPlan` route demonstrates how these functions could be used to
+produce a basic highlight plan.

--- a/highlightAlgorithm.js
+++ b/highlightAlgorithm.js
@@ -1,0 +1,82 @@
+// High level algorithm implementation for highlight reel generation
+// NOTE: This is a simplified skeleton that mirrors the steps outlined in
+// the docs. Actual video processing and AI models would be implemented
+// with appropriate libraries.
+
+function handleVideoUpload(video) {
+  // 1. Video Upload and Preprocessing
+  // - validate format
+  // - extract metadata
+  // - store or fetch from URL
+  // Placeholder implementation returning normalized video info
+  return {
+    source: video,
+    metadata: { duration: 0, resolution: '1080p' }
+  };
+}
+
+function processVideoSegments(video, focusMode, featuredPlayers, teamColors) {
+  // 2. Focus and Video Segmentation
+  // Segment video into clips based on focus mode or players
+  return [
+    { start: 0, end: 10, label: 'clip-1' },
+    { start: 10, end: 20, label: 'clip-2' }
+  ];
+}
+
+function detectHighlights(video, focusMode, userSettings) {
+  // 3. AI Highlight Detection and Customization
+  // Analyze segments for key actions
+  const segments = processVideoSegments(video, focusMode);
+  return segments.map(seg => ({ ...seg, confidence: 1.0 }));
+}
+
+function syncAudioWithVideo(clipList, musicTrack, commentaryStyle) {
+  // 4. Audio and Music Synchronization
+  return clipList.map(c => ({ ...c, audio: 'synced' }));
+}
+
+function applyVideoTransitions(clipList, transitionType, stylePreset) {
+  // 5. Video Transition and Effects
+  return clipList.map(c => ({ ...c, transition: transitionType }));
+}
+
+function renderHighlightReel(clipList, resolution, format) {
+  // 6. Highlight Reel Generation and Video Rendering
+  // Combine clips and return a placeholder file path
+  return `/tmp/highlight-${Date.now()}.${format}`;
+}
+
+function handleUserFeedback(feedback, video) {
+  // 7. Feedback and Revision Process
+  // In a real system this would reprocess the video based on feedback
+  return feedback;
+}
+
+function handleMonetization(userType, video) {
+  // 8. Monetization (Ad-Supported & Premium Models)
+  return userType === 'Premium' ? video : `ad-${video}`;
+}
+
+function manageSubscription(user, paymentDetails) {
+  // 9. Subscription & Payment Management
+  return { user, status: 'premium' };
+}
+
+function manageVideoStorage(user, video) {
+  // 10. Cloud Storage and Video Management
+  return { user, videoUrl: video };
+}
+
+module.exports = {
+  handleVideoUpload,
+  processVideoSegments,
+  detectHighlights,
+  syncAudioWithVideo,
+  applyVideoTransitions,
+  renderHighlightReel,
+  handleUserFeedback,
+  handleMonetization,
+  manageSubscription,
+  manageVideoStorage
+};

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const generateRenderPlan = require('./renderPlan');
+const highlight = require('./highlightAlgorithm');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -15,6 +16,16 @@ app.get('/api/health', (_req, res) => {
 app.post('/api/renderPlan', (req, res) => {
   const plan = generateRenderPlan(req.body || {});
   res.json({ plan });
+});
+
+// Example endpoint using the high level highlight algorithm
+app.post('/api/highlightPlan', (req, res) => {
+  const { video, focusMode, userSettings } = req.body || {};
+  const uploaded = highlight.handleVideoUpload(video);
+  let clips = highlight.detectHighlights(uploaded, focusMode, userSettings);
+  clips = highlight.applyVideoTransitions(clips, 'Fade', 'default');
+  const filePath = highlight.renderHighlightReel(clips, '1080p', 'mp4');
+  res.json({ filePath, clips });
 });
 
 app.listen(PORT, () =>


### PR DESCRIPTION
## Summary
- add skeleton implementation of highlight workflow
- expose `/api/highlightPlan` endpoint demonstrating usage
- document new module and dev command in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68421dad17548323a23e2af129c5fb3c