### PR TITLE
Add pay API stub and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # basketball-highlight-reel
 AI-powered basketball highlight reel generator.
+
+## Development
+
+### Payment Endpoint
+
+The server exposes a stubbed payment endpoint for integration testing:
+
+```
+POST /api/pay
+{
+  "amount": 5,
+  "currency": "USD"
+}
+```
+
+It responds with a generated `paymentId`.
+
+### Running Tests
+
+Run the basic endpoint test with:
+
+```bash
+npm test
+```
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI-powered basketball highlight reel generator.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node test/pay.test.js",
     "dev": "nodemon server.js"
   },
   "repository": {

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const cors = require('cors');
+const crypto = require('crypto');
 const generateRenderPlan = require('./renderPlan');
 
 const app = express();
@@ -17,7 +18,21 @@ app.post('/api/renderPlan', (req, res) => {
   res.json({ plan });
 });
 
-app.listen(PORT, () =>
-  console.log(`Server ready on http://localhost:${PORT}`)
-);
+// simple payment endpoint stub
+app.post('/api/pay', (req, res) => {
+  const { amount, currency } = req.body || {};
+  if (!amount || !currency) {
+    return res.status(400).json({ error: 'Missing payment details' });
+  }
+  const paymentId = crypto.randomBytes(8).toString('hex');
+  res.json({ paymentId, status: 'received', amount, currency });
+});
+
+if (require.main === module) {
+  app.listen(PORT, () =>
+    console.log(`Server ready on http://localhost:${PORT}`)
+  );
+}
+
+module.exports = app;
 

--- a/test/pay.test.js
+++ b/test/pay.test.js
@@ -1,0 +1,34 @@
+const http = require('http');
+const app = require('../server');
+const assert = require('assert');
+
+const PORT = 3050;
+const server = app.listen(PORT, () => {
+  const data = JSON.stringify({ amount: 5, currency: 'USD' });
+  const options = {
+    hostname: 'localhost',
+    port: PORT,
+    path: '/api/pay',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': data.length
+    }
+  };
+  const req = http.request(options, res => {
+    assert.equal(res.statusCode, 200);
+    let body = '';
+    res.on('data', chunk => body += chunk);
+    res.on('end', () => {
+      const json = JSON.parse(body);
+      assert.ok(json.paymentId);
+      server.close(() => process.exit(0));
+    });
+  });
+  req.on('error', err => {
+    console.error(err);
+    server.close(() => process.exit(1));
+  });
+  req.write(data);
+  req.end();
+});


### PR DESCRIPTION
## Summary
- add `/api/pay` endpoint for handling payments
- export Express app for external use
- add integration test covering the payment endpoint
- document payment endpoint and testing instructions

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68421d46f5b08323817afb34504213ec