### PR TITLE
Add monetization endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # basketball-highlight-reel
 AI-powered basketball highlight reel generator.
+
+## Monetization API
+
+This repo contains example endpoints to expose subscription plans and to mock
+purchasing those plans.  These are **not** full payment integrations but can be
+used by a front end to prototype plan selection flows.
+
+### `GET /api/plans`
+
+Returns available subscription and one‑time purchase options.
+
+### `POST /api/purchase`
+
+Accepts a `planId` and responds with the matching plan. In a real
+application this route would integrate with a payment gateway.

--- a/plans.js
+++ b/plans.js
@@ -1,0 +1,52 @@
+const plans = {
+  subscription: [
+    {
+      id: 'basic',
+      name: 'Basic Plan',
+      priceMonthly: 5,
+      videoQuality: '1080p',
+      highlightsPerMonth: 5,
+      features: ['basic AI assistance']
+    },
+    {
+      id: 'pro',
+      name: 'Pro Plan',
+      priceMonthly: 12,
+      videoQuality: '4K',
+      highlightsPerMonth: 'unlimited',
+      priorityRendering: true,
+      features: ['advanced AI', 'premium effects']
+    },
+    {
+      id: 'elite',
+      name: 'Elite Plan',
+      priceMonthly: 20,
+      videoQuality: '4K',
+      highlightsPerMonth: 'unlimited',
+      priorityRendering: true,
+      features: ['advanced AI', 'premium effects', 'exclusive styles']
+    }
+  ],
+  oneTime: [
+    {
+      id: 'basic-ot',
+      name: 'Basic One-Time',
+      price: 2,
+      videoQuality: '1080p'
+    },
+    {
+      id: 'premium-ot',
+      name: 'Premium One-Time',
+      price: 5,
+      videoQuality: '4K'
+    }
+  ]
+};
+
+function getPlans() {
+  return plans;
+}
+
+module.exports = {
+  getPlans
+};

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const generateRenderPlan = require('./renderPlan');
+const { getPlans } = require('./plans');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -15,6 +16,22 @@ app.get('/api/health', (_req, res) => {
 app.post('/api/renderPlan', (req, res) => {
   const plan = generateRenderPlan(req.body || {});
   res.json({ plan });
+});
+
+app.get('/api/plans', (_req, res) => {
+  res.json(getPlans());
+});
+
+app.post('/api/purchase', (req, res) => {
+  const { planId } = req.body || {};
+  const plans = getPlans();
+  const match = [...plans.subscription, ...plans.oneTime].find(p => p.id === planId);
+  if (!match) {
+    res.status(400).json({ error: 'Unknown plan' });
+    return;
+  }
+  // In a real app, integrate payment gateway here
+  res.json({ status: 'success', plan: match });
 });
 
 app.listen(PORT, () =>


### PR DESCRIPTION
## Summary
- add stub plan data with `plans.js`
- provide `/api/plans` and `/api/purchase` routes for prototypes
- document monetization API in README

## Testing
- `npm test` *(fails: "no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_68421d4300088323b7558e1d6de58f15