### PR TITLE
Add monetization plan documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # basketball-highlight-reel
+
 AI-powered basketball highlight reel generator.
+
+See [docs/MONETIZATION_PLAN.md](docs/MONETIZATION_PLAN.md) for a proposal on how to monetize the application with subscription tiers, one-time payments and an ad-supported free mode.

--- a/docs/MONETIZATION_PLAN.md
+++ b/docs/MONETIZATION_PLAN.md
@@ -1,0 +1,43 @@
+# Monetization Plan
+
+This document outlines a potential revenue model for the Basketball Highlight Reel application. It is a proposal only and not yet implemented in code.
+
+## 1. Subscription & Payment Options
+### 1.1 Monthly Subscription
+- **Basic Plan** – 1080p output, limited highlight reels, basic AI assistance.
+- **Pro Plan** – 4K output, unlimited reels, advanced AI, priority rendering, premium effects.
+- **Elite Plan** – all Pro features plus exclusive templates, styles, and early access to new tools.
+
+Subscribed users get no ads, faster rendering, high‑quality downloads, and access to exclusive libraries.
+
+### 1.2 One‑Time Payments
+- **Basic Fee** – generate one standard highlight reel (1080p) with standard effects.
+- **Premium Fee** – generate one premium reel (4K, custom transitions, advanced AI).
+
+Useful for users who do not want a recurring subscription.
+
+## 2. Free‑to‑Use Model with Ads
+- **Ad‑supported free version** – users watch ads during video processing.
+- **Rewarded ads** – users can watch longer ads for perks such as faster processing, temporary access to premium features, or credits toward premium reels.
+- **Ad‑free upgrades** – pay once or subscribe to remove ads entirely.
+
+## 3. Payment Integration and Flow
+- Integrate payment gateways (e.g., Stripe, PayPal, Apple/Google Pay).
+- Allow subscription management (cancel, upgrade/downgrade) from account settings.
+- Offer a 7‑ or 14‑day free trial for premium tiers.
+- Provide clear pricing pages and payment history.
+
+## 4. Rewards & Incentives
+- Credit system for watching ads that can be redeemed for faster rendering or premium effects.
+- Referral program to earn credits or discounts.
+
+## 5. Premium Features
+- Priority processing and dedicated support for paying users.
+- High‑quality video rendering up to 4K.
+- Exclusive effects, custom audio options, and watermark removal.
+
+## 6. Promotions
+- Seasonal discounts (e.g., Black Friday, New Year).
+
+---
+This plan is intended to guide future feature development.


### PR DESCRIPTION
## Summary
- document potential monetization model for highlight reels in `docs/MONETIZATION_PLAN.md`
- reference the monetization document from the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68421d410f4083239ad89a154a91dffb