### PR TITLE
Add basic highlight metadata API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # basketball-highlight-reel
 AI-powered basketball highlight reel generator.
+
+## API
+
+### `POST /api/highlights`
+
+Create a new highlight entry. Example payload:
+
+```json
+{
+  "title": "Rivalry Game Highlights",
+  "gameDate": "2024-03-12",
+  "description": "Top plays from the regular season finale",
+  "teamNames": ["Tigers", "Bears"],
+  "focusMode": "team",
+  "featuredPlayers": ["#23", "#42"],
+  "source": { "youtubeUrl": "https://youtu.be/example" }
+}
+```
+
+### `GET /api/highlights`
+
+Returns a list of all stored highlight metadata.
+
+### `GET /api/highlights/:id`
+
+Retrieve a specific highlight entry by id.

--- a/routes/highlights.js
+++ b/routes/highlights.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const router = express.Router();
+
+// In-memory store for highlight metadata
+const highlights = [];
+let idCounter = 1;
+
+// Create a highlight entry
+router.post('/', (req, res) => {
+  const {
+    title = '',
+    gameDate = '',
+    description = '',
+    teamNames = [],
+    focusMode = 'all',
+    featuredPlayers = [],
+    source = {}
+  } = req.body || {};
+
+  const highlight = {
+    id: idCounter++,
+    title,
+    gameDate,
+    description,
+    teamNames,
+    focusMode,
+    featuredPlayers,
+    source
+  };
+
+  highlights.push(highlight);
+  res.status(201).json({ highlight });
+});
+
+// List all highlights
+router.get('/', (_req, res) => {
+  res.json({ highlights });
+});
+
+// Retrieve a single highlight
+router.get('/:id', (req, res) => {
+  const id = Number(req.params.id);
+  const highlight = highlights.find((h) => h.id === id);
+  if (!highlight) {
+    return res.status(404).json({ error: 'Highlight not found' });
+  }
+  res.json({ highlight });
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const generateRenderPlan = require('./renderPlan');
+const highlightRoutes = require('./routes/highlights');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -16,6 +17,9 @@ app.post('/api/renderPlan', (req, res) => {
   const plan = generateRenderPlan(req.body || {});
   res.json({ plan });
 });
+
+// Highlight metadata endpoints
+app.use('/api/highlights', highlightRoutes);
 
 app.listen(PORT, () =>
   console.log(`Server ready on http://localhost:${PORT}`)


### PR DESCRIPTION
## Summary
- introduce routes for creating and listing highlight metadata
- wire routes into the express server
- document new endpoints in README

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_68421cf7c03c83238449d2e201554523