### PR TITLE
Add renderPlan options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # basketball-highlight-reel
 AI-powered basketball highlight reel generator.
+
+## Render Plan API
+
+The `/api/renderPlan` endpoint accepts the following options:
+
+- `focusMode` – one of `all`, `team`, or `player` (default `all`)
+- `structureType` – `montage`, `countdown`, or `chronological` (default `montage`)
+- `duration` – total length of the reel in seconds (default `60`)
+- `highlightCount` – number of clips to include (default `5`)
+- `resolution` – output resolution such as `720p`, `1080p`, or `4K` (default `1080p`)
+
+The response contains a simple list of clips with start and end times
+demonstrating where highlights could be placed.

--- a/renderPlan.js
+++ b/renderPlan.js
@@ -1,11 +1,29 @@
 function generateRenderPlan(opts = {}) {
+  const {
+    focusMode = 'all',
+    structureType = 'montage',
+    duration = 60,
+    highlightCount = 5,
+    resolution = '1080p',
+  } = opts;
+
+  const clipLength = Math.floor(duration / highlightCount);
+  const clips = Array.from({ length: highlightCount }, (_, i) => ({
+    start: i * clipLength,
+    end: i * clipLength + clipLength,
+    label:
+      structureType === 'countdown'
+        ? `highlight-${highlightCount - i}`
+        : `highlight-${i + 1}`,
+  }));
+
   return {
-    ...opts,
-    clips: [
-      { start: 12, end: 20, label: 'dunk' },
-      { start: 45, end: 52, label: 'three-pointer' },
-      { start: 87, end: 94, label: 'fast break' }
-    ]
+    focusMode,
+    structureType,
+    duration,
+    highlightCount,
+    resolution,
+    clips,
   };
 }
 module.exports = generateRenderPlan;


### PR DESCRIPTION
## Summary
- add initial planning options to `renderPlan`
- document the options in `README`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68421cf36a108323aae59decbf96ac25