### PR TITLE
Implement configurable highlight plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # basketball-highlight-reel
-AI-powered basketball highlight reel generator.
+
+Small demo API for generating basketball highlight reel plans.
+
+## Running the server
+
+```bash
+npm install
+npm run dev
+```
+
+The server exposes two endpoints:
+
+- `GET /api/health` – simple health check.
+- `POST /api/renderPlan` – generate a highlight plan.
+
+## Render plan options
+
+`POST /api/renderPlan` accepts a JSON body with the following optional fields:
+
+- `title` – name of the reel.
+- `gameDate` – date of the game.
+- `description` – short description.
+- `focusMode` – `all`, `team`, or `player`.
+- `structureType` – `montage`, `countdown`, or `chronological`.
+- `duration` – total video length in seconds.
+- `highlightCount` – how many highlights to include.
+- `resolution` – video resolution such as `720p` or `1080p`.
+- `stylePreset` – stylistic preset for the edit.
+
+The response contains the merged options, a simple list of clip timecodes, and a
+few AI-style suggestions.
+
+This project is not a full video editor but provides a starting point for an
+AI-assisted highlight workflow.

--- a/renderPlan.js
+++ b/renderPlan.js
@@ -1,12 +1,36 @@
-function generateRenderPlan(opts = {}) {
-  return {
-    ...opts,
-    clips: [
-      { start: 12, end: 20, label: 'dunk' },
-      { start: 45, end: 52, label: 'three-pointer' },
-      { start: 87, end: 94, label: 'fast break' }
-    ]
-  };
-}
-module.exports = generateRenderPlan;
+const DEFAULTS = {
+  title: 'Highlight Reel',
+  gameDate: null,
+  description: '',
+  focusMode: 'all',
+  structureType: 'montage',
+  duration: 60, // seconds
+  highlightCount: 3,
+  resolution: '1080p',
+  stylePreset: 'standard',
+  commentaryStyle: 'excited',
+  musicGenre: 'hiphop',
+  introText: '',
+  outroText: ''
+};
 
+function generateRenderPlan(opts = {}) {
+  const plan = { ...DEFAULTS, ...opts };
+
+  // simple demo clip generation
+  plan.clips = Array.from({ length: plan.highlightCount }, (_v, i) => {
+    const start = Math.round((i * plan.duration) / plan.highlightCount);
+    const end = start + 5;
+    return { start, end, label: `highlight-${i + 1}` };
+  });
+
+  // basic AI-style suggestions
+  plan.suggestions = [
+    'Consider adding slow motion to your best plays.',
+    'Try a cinematic style preset for dramatic effect.'
+  ];
+
+  return plan;
+}
+
+module.exports = generateRenderPlan;


### PR DESCRIPTION
## Summary
- expand README with usage instructions
- allow `/api/renderPlan` to accept options like focus mode, structure type, and duration
- generate simple clips and suggestions in `generateRenderPlan`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68421ce791d083239f94571ca6c28687