### PR TITLE
Add feature roadmap and configurable render options

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,49 @@
+# Proposed Features for Basketball Highlight Reel App
+
+This document outlines a comprehensive set of features for an AI-powered basketball highlight reel generator. The list aggregates ideas for future development and acts as a high level product plan.
+
+## 1. Video Creation & Editing
+- Upload video files or specify a YouTube link.
+- Set game information such as title, date, descriptions, and team colors.
+- Choose focus modes (all players, a specific team, or individuals) and list featured players.
+- Pick the structure of the highlight reel (montage, countdown, chronological).
+- Configure output options like duration, resolution, aspect ratio, and visual effects.
+
+## 2. AI Assistance & Editing Dashboard
+- Drag-and-drop timeline with real-time preview.
+- Option for full AI takeover to automatically select highlights, transitions, and music.
+- Step-by-step suggestions from the AI while editing.
+- Save custom templates and effects for reuse.
+
+## 3. Profile & Stats
+- Display created reels, game stats, and top moments in a user dashboard.
+- Track past games with advanced analytics and improvement suggestions.
+
+## 4. Social & Community
+- Collaborate with teammates on shared highlight reels.
+- Leaderboards and voting for the best plays.
+- Easy sharing to social media with hashtag suggestions.
+
+## 5. Advanced Scouting
+- Generate scouting reports focused on individual players or teams.
+- Options for coach feedback and virtual sessions.
+
+## 6. Training & Skill Tracking
+- Monitor skill improvements over time and suggest drills based on video analysis.
+- Set goals and review progress reports.
+
+## 7. Video Effects & AR
+- Apply cinematic filters, slow motion, and speed ramping.
+- Explore augmented reality effects for shot tracking and highlights.
+
+## 8. Feedback & Revisions
+- Users can give feedback on generated videos and track revision history.
+
+## 9. Monetization & Marketing
+- Support custom watermarks and team branding.
+- Subscription tiers for premium features and potential revenue sharing.
+
+## 10. Security & Privacy
+- Secure storage for user data and parental control options.
+
+These ideas are intended as a roadmap for future development. The current project implements only a small subset of the functionality described here.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # basketball-highlight-reel
+
 AI-powered basketball highlight reel generator.
+
+For a detailed overview of the planned functionality check the
+[FEATURES.md](FEATURES.md) document.

--- a/renderPlan.js
+++ b/renderPlan.js
@@ -1,12 +1,30 @@
 function generateRenderPlan(opts = {}) {
+  const {
+    structureType = 'montage',
+    duration = 60,
+    highlightCount = 3,
+    resolution = '1080p',
+    outputFormat = 'landscape',
+    focus = 'all',
+    clips = []
+  } = opts;
+
+  const defaultClips = [
+    { start: 12, end: 20, label: 'dunk' },
+    { start: 45, end: 52, label: 'three-pointer' },
+    { start: 87, end: 94, label: 'fast break' }
+  ];
+
   return {
-    ...opts,
-    clips: [
-      { start: 12, end: 20, label: 'dunk' },
-      { start: 45, end: 52, label: 'three-pointer' },
-      { start: 87, end: 94, label: 'fast break' }
-    ]
+    structureType,
+    duration,
+    highlightCount,
+    resolution,
+    outputFormat,
+    focus,
+    clips: clips.length ? clips.slice(0, highlightCount) : defaultClips.slice(0, highlightCount)
   };
 }
+
 module.exports = generateRenderPlan;
 


### PR DESCRIPTION
## Summary
- update `renderPlan` to accept highlight render options
- link README to a new feature roadmap doc
- document proposed app features

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68421ce44440832384f8d460c2ac0a89