### PR TITLE
Implement expanded renderPlan options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# basketball-highlight-reel
-AI-powered basketball highlight reel generator.
+# Basketball Highlight Reel
+
+Simple API for generating a basic render plan for a basketball highlight
+reel.  The `/api/renderPlan` endpoint accepts an options object and returns
+a JSON plan describing how the video should be edited.  The plan now
+supports extra metadata like game information, team colors and style
+preferences.
+
+Example request:
+
+```bash
+curl -X POST http://localhost:3000/api/renderPlan \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Championship Highlights","structure":{"type":"countdown"}}'
+```
+
+Example response (truncated):
+
+```json
+{
+  "title": "Championship Highlights",
+  "structure": { "type": "countdown", "duration": 30, "highlightCount": 5 },
+  "clips": [
+    { "start": 12, "end": 20, "label": "dunk" }
+  ]
+}
+```

--- a/renderPlan.js
+++ b/renderPlan.js
@@ -1,12 +1,61 @@
 function generateRenderPlan(opts = {}) {
-  return {
-    ...opts,
-    clips: [
-      { start: 12, end: 20, label: 'dunk' },
-      { start: 45, end: 52, label: 'three-pointer' },
-      { start: 87, end: 94, label: 'fast break' }
-    ]
+  const defaults = {
+    title: 'Untitled Highlight Reel',
+    gameDate: null,
+    description: '',
+    teams: [
+      { name: 'Home', color: '#ff0000' },
+      { name: 'Away', color: '#0000ff' }
+    ],
+    focus: {
+      mode: 'all',
+      featuredPlayers: []
+    },
+    structure: {
+      type: 'montage',
+      duration: 30,
+      highlightCount: 5
+    },
+    resolution: '1080p',
+    aspectRatio: 'landscape',
+    style: {
+      preset: 'standard',
+      customEffects: []
+    },
+    audio: {
+      commentaryStyle: 'excited',
+      music: 'hip-hop',
+      levels: { commentary: 0.8, music: 0.5, game: 0.7 }
+    },
+    effects: {
+      slowMotion: 0,
+      replay: true,
+      zoom: 0
+    },
+    intro: { text: '', branding: null },
+    outro: { text: '', branding: null }
   };
+
+  const config = {
+    ...defaults,
+    ...opts,
+    teams: opts.teams || defaults.teams,
+    focus: { ...defaults.focus, ...(opts.focus || {}) },
+    structure: { ...defaults.structure, ...(opts.structure || {}) },
+    style: { ...defaults.style, ...(opts.style || {}) },
+    audio: { ...defaults.audio, ...(opts.audio || {}) },
+    effects: { ...defaults.effects, ...(opts.effects || {}) },
+    intro: { ...defaults.intro, ...(opts.intro || {}) },
+    outro: { ...defaults.outro, ...(opts.outro || {}) }
+  };
+
+  const clips = opts.clips || [
+    { start: 12, end: 20, label: 'dunk' },
+    { start: 45, end: 52, label: 'three-pointer' },
+    { start: 87, end: 94, label: 'fast break' }
+  ];
+
+  return { ...config, clips };
 }
 module.exports = generateRenderPlan;
 


### PR DESCRIPTION
## Summary
- expand `renderPlan` defaults to cover more metadata
- document how to call `/api/renderPlan`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68421cda432c83238f276751272d184b