### PR TITLE
Add upload API and options structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+uploads/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # basketball-highlight-reel
 AI-powered basketball highlight reel generator.
+
+## Usage
+
+Start the server with `node server.js` and interact with the following endpoints:
+
+### `POST /api/uploads`
+Upload a base64 encoded video. Body should include:
+```
+{
+  "data": "BASE64_STRING",
+  "extension": "mp4" // optional
+}
+```
+Returns the stored file id and filename.
+
+### `GET /api/uploads`
+Returns a list of previously uploaded videos.
+
+### `POST /api/renderPlan`
+Pass highlight options grouped by section:
+```
+{
+  "videoSource": { ... },
+  "basicInfo": { ... },
+  "focusSettings": { ... },
+  "highlightStructure": { ... },
+  "styleSettings": { ... },
+  "visualEffects": { ... },
+  "audioSettings": { ... },
+  "introOutro": { ... },
+  "advancedOptions": { ... }
+}
+```
+The response contains the same options plus a mock list of clips.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "nodemon": "^3.1.10"
+    "multer": "^1.4.5",
+    "nodemon": "^3.1.10",
+    "uuid": "^9.0.0"
   }
 }

--- a/renderPlan.js
+++ b/renderPlan.js
@@ -1,12 +1,32 @@
-function generateRenderPlan(opts = {}) {
+function generateRenderPlan(options = {}) {
+  const {
+    videoSource = {},
+    basicInfo = {},
+    focusSettings = {},
+    highlightStructure = {},
+    styleSettings = {},
+    visualEffects = {},
+    audioSettings = {},
+    introOutro = {},
+    advancedOptions = {},
+  } = options;
+
   return {
-    ...opts,
+    videoSource,
+    basicInfo,
+    focusSettings,
+    highlightStructure,
+    styleSettings,
+    visualEffects,
+    audioSettings,
+    introOutro,
+    advancedOptions,
     clips: [
       { start: 12, end: 20, label: 'dunk' },
       { start: 45, end: 52, label: 'three-pointer' },
-      { start: 87, end: 94, label: 'fast break' }
-    ]
+      { start: 87, end: 94, label: 'fast break' },
+    ],
   };
 }
-module.exports = generateRenderPlan;
 
+module.exports = generateRenderPlan;

--- a/server.js
+++ b/server.js
@@ -1,15 +1,33 @@
 const express = require('express');
 const cors = require('cors');
+const path = require('path');
 const generateRenderPlan = require('./renderPlan');
+const { saveBase64Video, listUploads, UPLOAD_DIR } = require('./uploadManager');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(cors());
-app.use(express.json());
+app.use(express.json({ limit: '50mb' }));
+app.use('/uploads', express.static(UPLOAD_DIR));
 
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', message: 'Highlight backend running 🎉' });
+});
+
+// Upload a base64-encoded video
+app.post('/api/uploads', (req, res) => {
+  const { data, extension } = req.body || {};
+  if (!data) {
+    return res.status(400).json({ error: 'Missing video data' });
+  }
+  const file = saveBase64Video(data, extension);
+  res.json({ file });
+});
+
+// List uploaded videos
+app.get('/api/uploads', (_req, res) => {
+  res.json({ files: listUploads() });
 });
 
 app.post('/api/renderPlan', (req, res) => {
@@ -20,4 +38,3 @@ app.post('/api/renderPlan', (req, res) => {
 app.listen(PORT, () =>
   console.log(`Server ready on http://localhost:${PORT}`)
 );
-

--- a/uploadManager.js
+++ b/uploadManager.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const UPLOAD_DIR = path.join(__dirname, 'uploads');
+
+function ensureDir() {
+  if (!fs.existsSync(UPLOAD_DIR)) {
+    fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+  }
+}
+
+function saveBase64Video(data, extension = 'mp4') {
+  ensureDir();
+  const id = crypto.randomUUID();
+  const filename = `${id}.${extension}`;
+  const filePath = path.join(UPLOAD_DIR, filename);
+  const buffer = Buffer.from(data, 'base64');
+  fs.writeFileSync(filePath, buffer);
+  return { id, filename };
+}
+
+function listUploads() {
+  ensureDir();
+  return fs
+    .readdirSync(UPLOAD_DIR)
+    .filter((f) => !f.startsWith('.'))
+    .map((f) => ({ id: path.parse(f).name, filename: f }));
+}
+
+module.exports = {
+  saveBase64Video,
+  listUploads,
+  UPLOAD_DIR,
+};


### PR DESCRIPTION
## Summary
- handle base64 uploads and list uploaded videos
- expand render plan to include all settings sections
- expose uploaded files via static route
- document API usage in README
- ignore generated uploads directory
- include multer and uuid dependencies in package.json

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm install` *(fails: 403 Forbidden for multer)*

------
https://chatgpt.com/codex/tasks/task_e_684219442e9883238b08cc50df3833d0