### PR TITLE
Add feedback endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # basketball-highlight-reel
 AI-powered basketball highlight reel generator.
+
+## API
+
+### `POST /api/renderPlan`
+Generate a simple render plan for a highlight reel. Expects JSON
+describing options and returns a list of clips.
+
+### `POST /api/feedback`
+Submit feedback about a generated highlight reel. The request body can
+contain any fields and will be stored in memory.
+
+### `GET /api/feedback`
+Retrieve all feedback that has been submitted during the server's
+current session.

--- a/feedbackStore.js
+++ b/feedbackStore.js
@@ -1,0 +1,13 @@
+const feedbackList = [];
+
+function addFeedback(feedback) {
+  if (feedback && typeof feedback === 'object') {
+    feedbackList.push({ ...feedback, timestamp: Date.now() });
+  }
+}
+
+function getAllFeedback() {
+  return feedbackList;
+}
+
+module.exports = { addFeedback, getAllFeedback };

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const generateRenderPlan = require('./renderPlan');
+const { addFeedback, getAllFeedback } = require('./feedbackStore');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -15,6 +16,15 @@ app.get('/api/health', (_req, res) => {
 app.post('/api/renderPlan', (req, res) => {
   const plan = generateRenderPlan(req.body || {});
   res.json({ plan });
+});
+
+app.post('/api/feedback', (req, res) => {
+  addFeedback(req.body);
+  res.json({ status: 'received' });
+});
+
+app.get('/api/feedback', (_req, res) => {
+  res.json({ feedback: getAllFeedback() });
 });
 
 app.listen(PORT, () =>


### PR DESCRIPTION
## Summary
- add a simple in-memory feedback store
- expose `/api/feedback` POST and GET endpoints
- document available endpoints in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684219f157dc8323932243b12dd5e72a