### PR TITLE
Add flexible render plan options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # basketball-highlight-reel
-AI-powered basketball highlight reel generator.
+
+Simple Express API for generating basketball highlight reel plans.
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+npm install
+npm run dev
+```
+
+The server listens on `http://localhost:3000` by default.
+
+## API
+
+### `GET /api/health`
+
+Health check endpoint. Returns a simple status message.
+
+### `POST /api/renderPlan`
+
+Generate a highlight reel render plan. The request body accepts various
+fields describing the video, teams and desired style. Example:
+
+```json
+{
+  "title": "Top Plays",
+  "gameDate": "2024-06-14",
+  "teams": [
+    { "name": "Raptors", "color": "#ce1141" },
+    { "name": "Lakers", "color": "#552583" }
+  ],
+  "structure": { "type": "montage", "highlightCount": 10 },
+  "style": { "preset": "broadcast" }
+}
+```
+
+The response contains the full plan with defaults applied.

--- a/renderPlan.js
+++ b/renderPlan.js
@@ -1,11 +1,62 @@
 function generateRenderPlan(opts = {}) {
-  return {
-    ...opts,
-    clips: [
+  const {
+    videoSource,
+    title = 'Highlight Reel',
+    gameDate = '',
+    gameDescription = '',
+    teams = [],
+    focusMode = 'all',
+    featuredPlayers = [],
+    jerseyNumbers = {},
+    playerDescriptions = {},
+    structure = {},
+    output = {},
+    style = {},
+    audio = {},
+    effects = {},
+    intro = {},
+    outro = {},
+    aiAssisted = true,
+    clips = [
       { start: 12, end: 20, label: 'dunk' },
       { start: 45, end: 52, label: 'three-pointer' },
       { start: 87, end: 94, label: 'fast break' }
     ]
+  } = opts;
+
+  return {
+    videoSource,
+    title,
+    gameDate,
+    gameDescription,
+    teams,
+    focusMode,
+    featuredPlayers,
+    jerseyNumbers,
+    playerDescriptions,
+    structure: {
+      type: structure.type || 'montage',
+      highlightCount: structure.highlightCount || 5,
+      duration: structure.duration || 60
+    },
+    output: {
+      resolution: output.resolution || '1080p',
+      aspectRatio: output.aspectRatio || 'landscape'
+    },
+    style: {
+      preset: style.preset || 'standard',
+      effects: style.effects || []
+    },
+    audio: {
+      commentary: audio.commentary || 'excited',
+      music: audio.music || null,
+      levels: audio.levels || { commentary: 0.8, music: 0.6, game: 1 }
+    },
+    effects,
+    intro,
+    outro,
+    clips,
+    aiAssisted
   };
 }
 module.exports = generateRenderPlan;


### PR DESCRIPTION
## Summary
- support more fields in `generateRenderPlan`
- document usage and endpoints in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68421cd155688323bc561f006c35ebbe