### PR TITLE
Add advanced analytics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # basketball-highlight-reel
 AI-powered basketball highlight reel generator.
+
+## API Endpoints
+
+### `POST /api/advancedStats`
+
+Calculates advanced statistics from a set of player stats. The request body
+should contain fields like `points`, `fgAttempts`, `ftAttempts`, `assists`, and
+more. The response includes:
+
+- `tsPercent` – true shooting percentage
+- `per` – a simplified Player Efficiency Rating
+- `impact` – custom player impact score
+
+### `POST /api/gameComparison`
+
+Accepts an array of game stat objects and returns the same list with advanced
+metrics added for each game. This is useful for comparing performances across
+multiple games or seasons.

--- a/analytics.js
+++ b/analytics.js
@@ -1,0 +1,22 @@
+function trueShootingPercentage(points, fga, fta) {
+  const divisor = 2 * (fga + 0.44 * fta);
+  if (!divisor) return 0;
+  return +(points / divisor).toFixed(3);
+}
+
+function simplePER({ points = 0, rebounds = 0, assists = 0, steals = 0, blocks = 0, turnovers = 0, fgAttempts = 0, ftAttempts = 0 }) {
+  const ts = trueShootingPercentage(points, fgAttempts, ftAttempts);
+  const efficiency = points + rebounds * 1.2 + assists * 1.5 + steals * 2 + blocks * 2 - turnovers * 2;
+  return +(efficiency * ts).toFixed(3);
+}
+
+function playerImpactScore({ points = 0, assists = 0, rebounds = 0, steals = 0, blocks = 0, turnovers = 0 }) {
+  const score = points + assists * 0.7 + rebounds * 0.7 + steals * 1.5 + blocks * 1.2 - turnovers;
+  return +score.toFixed(3);
+}
+
+module.exports = {
+  trueShootingPercentage,
+  simplePER,
+  playerImpactScore,
+};

--- a/server.js
+++ b/server.js
@@ -1,6 +1,11 @@
 const express = require('express');
 const cors = require('cors');
 const generateRenderPlan = require('./renderPlan');
+const {
+  trueShootingPercentage,
+  simplePER,
+  playerImpactScore,
+} = require('./analytics');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -15,6 +20,25 @@ app.get('/api/health', (_req, res) => {
 app.post('/api/renderPlan', (req, res) => {
   const plan = generateRenderPlan(req.body || {});
   res.json({ plan });
+});
+
+app.post('/api/advancedStats', (req, res) => {
+  const data = req.body || {};
+  const tsPercent = trueShootingPercentage(data.points, data.fgAttempts, data.ftAttempts);
+  const per = simplePER(data);
+  const impact = playerImpactScore(data);
+  res.json({ tsPercent, per, impact });
+});
+
+app.post('/api/gameComparison', (req, res) => {
+  const { games = [] } = req.body || {};
+  const results = games.map(g => ({
+    ...g,
+    tsPercent: trueShootingPercentage(g.points, g.fgAttempts, g.ftAttempts),
+    per: simplePER(g),
+    impact: playerImpactScore(g),
+  }));
+  res.json({ games: results });
 });
 
 app.listen(PORT, () =>


### PR DESCRIPTION
## Summary
- add analytics functions for advanced stats like true shooting percentage, PER, and a custom impact score
- expose `/api/advancedStats` and `/api/gameComparison` endpoints
- document new API endpoints in the README

## Testing
- `node -e "require('./server');"` *(fails: Cannot find module 'express')*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68421ca0d0988323af3a9937d80d8664