### PR TITLE
Add analytics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # basketball-highlight-reel
+
 AI-powered basketball highlight reel generator.
+
+## API Endpoints
+
+### `POST /api/renderPlan`
+Generates a simple render plan based on the provided options.
+
+### `POST /api/analytics`
+Calculates advanced metrics like True Shooting percentage and a custom player impact score based on player stats.
+
+### `GET /api/health`
+Health check endpoint returning service status.

--- a/analytics.js
+++ b/analytics.js
@@ -1,0 +1,23 @@
+function trueShootingPercentage({ points = 0, fga = 0, fta = 0 } = {}) {
+  const denom = 2 * (fga + 0.44 * fta);
+  if (denom === 0) return 0;
+  return points / denom;
+}
+
+function playerImpactScore({ points = 0, assists = 0, rebounds = 0, steals = 0, blocks = 0, turnovers = 0 } = {}) {
+  // Simplified custom formula
+  return points + 1.5 * assists + 1.2 * rebounds + 2 * (steals + blocks) - turnovers;
+}
+
+function calculateMetrics(stats = {}) {
+  return {
+    ts: trueShootingPercentage(stats),
+    impact: playerImpactScore(stats)
+  };
+}
+
+module.exports = {
+  calculateMetrics,
+  trueShootingPercentage,
+  playerImpactScore
+};

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const generateRenderPlan = require('./renderPlan');
+const { calculateMetrics } = require('./analytics');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -15,6 +16,11 @@ app.get('/api/health', (_req, res) => {
 app.post('/api/renderPlan', (req, res) => {
   const plan = generateRenderPlan(req.body || {});
   res.json({ plan });
+});
+
+app.post('/api/analytics', (req, res) => {
+  const metrics = calculateMetrics(req.body || {});
+  res.json({ metrics });
 });
 
 app.listen(PORT, () =>


### PR DESCRIPTION
## Summary
- add simple analytics functions
- expose new `/api/analytics` route
- document endpoints in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68421c9d6b9c83238171a7769a8b28c7