### PR TITLE
Add player impact score endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # basketball-highlight-reel
 AI-powered basketball highlight reel generator.
+
+## API
+
+### `POST /api/impactScore`
+
+Calculate a player's impact score from basic box score data. Pass a JSON body with any of the following fields:
+
+```
+{
+  "points": 0,
+  "assists": 0,
+  "rebounds": 0,
+  "steals": 0,
+  "blocks": 0,
+  "turnovers": 0,
+  "minutesPlayed": 0
+}
+```
+
+The response will contain a numeric `score` representing contribution per minute.

--- a/impactScore.js
+++ b/impactScore.js
@@ -1,0 +1,23 @@
+function calculateImpactScore(stats = {}) {
+  const {
+    points = 0,
+    assists = 0,
+    rebounds = 0,
+    steals = 0,
+    blocks = 0,
+    turnovers = 0,
+    minutesPlayed = 1
+  } = stats;
+
+  const rawScore =
+    points +
+    assists * 1.5 +
+    rebounds * 1.2 +
+    steals * 3 +
+    blocks * 3 -
+    turnovers * 2;
+
+  return Number((rawScore / minutesPlayed).toFixed(2));
+}
+
+module.exports = calculateImpactScore;

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const generateRenderPlan = require('./renderPlan');
+const calculateImpactScore = require('./impactScore');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -15,6 +16,11 @@ app.get('/api/health', (_req, res) => {
 app.post('/api/renderPlan', (req, res) => {
   const plan = generateRenderPlan(req.body || {});
   res.json({ plan });
+});
+
+app.post('/api/impactScore', (req, res) => {
+  const score = calculateImpactScore(req.body || {});
+  res.json({ score });
 });
 
 app.listen(PORT, () =>


### PR DESCRIPTION
## Summary
- introduce `calculateImpactScore` helper for player metrics
- expose new `/api/impactScore` endpoint
- document the endpoint in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68421c9a2bf483238abb38c857cd2b3f