### PR TITLE
Add profile summary endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # basketball-highlight-reel
 AI-powered basketball highlight reel generator.
+
+## API Endpoints
+
+- `GET /api/health` – simple health check.
+- `POST /api/renderPlan` – returns a highlight render plan for uploaded video data.
+- `POST /api/profile` – generates a profile summary including user stats and reels.

--- a/profileData.js
+++ b/profileData.js
@@ -1,0 +1,24 @@
+function generateProfile(opts = {}) {
+  const {
+    name = 'Player',
+    profilePicture = '',
+    team = '',
+    reels = []
+  } = opts;
+
+  const totalReels = reels.length;
+  const totalPoints = reels.reduce((sum, reel) => sum + (reel.stats?.points || 0), 0);
+  const avgPoints = totalReels ? totalPoints / totalReels : 0;
+
+  return {
+    user: { name, profilePicture, team },
+    totalReels,
+    stats: {
+      totalPoints,
+      averagePointsPerGame: Number(avgPoints.toFixed(2))
+    },
+    reels
+  };
+}
+
+module.exports = generateProfile;

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const generateRenderPlan = require('./renderPlan');
+const generateProfile = require('./profileData');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -15,6 +16,11 @@ app.get('/api/health', (_req, res) => {
 app.post('/api/renderPlan', (req, res) => {
   const plan = generateRenderPlan(req.body || {});
   res.json({ plan });
+});
+
+app.post('/api/profile', (req, res) => {
+  const profile = generateProfile(req.body || {});
+  res.json({ profile });
 });
 
 app.listen(PORT, () =>


### PR DESCRIPTION
## Summary
- introduce profile generation helper
- expose `/api/profile` endpoint
- document all available endpoints in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68421ab62ec4832398ec5538769d8212