### PR TITLE
Add basic realtime support and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready" --health-interval 10s --health-timeout 5s --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # basketball-highlight-reel
+
 AI-powered basketball highlight reel generator.
+
+This project includes a tiny Express backend and example realtime helpers for progress updates and presence using Supabase and Redis. Playwright is used for simple integration tests and the CI workflow spins up Postgres and Redis services.

--- a/client/hooks/usePresence.ts
+++ b/client/hooks/usePresence.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { createClient } from '@supabase/supabase-js';
+
+const supa = createClient(
+  import.meta.env.VITE_SUPA_URL as string,
+  import.meta.env.VITE_SUPA_ANON as string
+);
+
+export interface PresenceInfo {
+  uid: string;
+  cursorTime: number;
+}
+
+export function usePresence(reelId: string) {
+  const [members, setMembers] = useState<PresenceInfo[]>([]);
+
+  useEffect(() => {
+    const channel = supa.channel(`reel:${reelId}`, { config: { presence: { key: 'uid' } } });
+
+    channel.on('presence', { event: 'sync' }, () => {
+      const state = channel.presenceState<PresenceInfo>();
+      const list: PresenceInfo[] = Object.values(state).flat();
+      setMembers(list);
+    });
+
+    channel.subscribe(async status => {
+      if (status === 'SUBSCRIBED') {
+        channel.track({ uid: supa.auth.getUser().data?.user?.id || 'anon', cursorTime: 0 });
+      }
+    });
+
+    const interval = setInterval(() => {
+      channel.track({ uid: supa.auth.getUser().data?.user?.id || 'anon', cursorTime: Date.now() });
+    }, 1000);
+
+    return () => {
+      clearInterval(interval);
+      channel.unsubscribe();
+    };
+  }, [reelId]);
+
+  return members;
+}

--- a/client/hooks/useProcessing.ts
+++ b/client/hooks/useProcessing.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import { createClient } from '@supabase/supabase-js';
+
+const supa = createClient(
+  import.meta.env.VITE_SUPA_URL as string,
+  import.meta.env.VITE_SUPA_ANON as string
+);
+
+export function useProcessing(videoId: string) {
+  const [pct, setPct] = useState(0);
+
+  useEffect(() => {
+    const ch = supa.channel(`processing:${videoId}`);
+    ch.on('broadcast', { event: 'tick' }, payload => setPct(payload.pct));
+    ch.subscribe();
+    return () => {
+      ch.unsubscribe();
+    };
+  }, [videoId]);
+
+  return pct;
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI-powered basketball highlight reel generator.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "playwright test",
     "dev": "nodemon server.js"
   },
   "repository": {
@@ -22,6 +22,11 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "@supabase/supabase-js": "^2.39.5",
+    "ioredis": "^5.3.2"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.38.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,12 @@
+// basic Playwright config
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+const config = {
+  testDir: './tests',
+  webServer: {
+    command: 'node server.js',
+    port: 3000,
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+};
+export default config;

--- a/server/videoQueue.js
+++ b/server/videoQueue.js
@@ -1,0 +1,20 @@
+import { createClient } from '@supabase/supabase-js';
+import Redis from 'ioredis';
+
+const supa = createClient(process.env.SUPA_URL, process.env.SUPA_KEY);
+const pub = new Redis(process.env.REDIS_URL);
+
+export async function publishProgress(videoId, pct) {
+  await pub.publish(`progress:${videoId}`, JSON.stringify({ pct }));
+}
+
+const sub = new Redis(process.env.REDIS_URL);
+sub.psubscribe('progress:*');
+sub.on('pmessage', async (_, chan, msg) => {
+  const videoId = chan.split(':')[1];
+  await supa.channel(`processing:${videoId}`).send({
+    type: 'broadcast',
+    event: 'tick',
+    payload: JSON.parse(msg)
+  });
+});

--- a/tests/progress.spec.ts
+++ b/tests/progress.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('server health endpoint', async ({ request }) => {
+  const res = await request.get('http://localhost:3000/api/health');
+  expect(res.ok()).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- implement Redis→Supabase progress bridge
- add React hooks for progress and presence
- add Playwright test and config
- configure GitHub Actions to run tests with Postgres and Redis

## Testing
- `npm test` *(fails: playwright not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842256a5d948323aa8075f012d0dcf8